### PR TITLE
Render chatbot messages with Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "framer-motion": "^12.19.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^8.0.7"
   },
   "devDependencies": {
     "@types/node": "^24.0.7",

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import ReactMarkdown from 'react-markdown';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';
@@ -138,7 +139,27 @@ export default function Chatbot() {
                     msg.role === 'user' ? 'bg-blue-100 text-right' : 'bg-gray-100 text-left'
                   }`}
                 >
-                  <span>{msg.content}</span>
+                  <ReactMarkdown
+                    className="text-sm break-words whitespace-pre-wrap"
+                    components={{
+                      a: ({node, ...props}) => (
+                        <a
+                          {...props}
+                          className="text-blue-600 underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      ),
+                      ul: ({node, ...props}) => (
+                        <ul className="list-disc pl-5" {...props} />
+                      ),
+                      ol: ({node, ...props}) => (
+                        <ol className="list-decimal pl-5" {...props} />
+                      ),
+                    }}
+                  >
+                    {msg.content}
+                  </ReactMarkdown>
                 </div>
               ))}
               <div ref={messagesEndRef} />


### PR DESCRIPTION
## Summary
- add `react-markdown` dependency
- render bot messages using `ReactMarkdown`
- style markdown content so links and lists work inside chat bubbles

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686710bb5c20832186f30613a1fa9eb2