### PR TITLE
Render chatbot messages with Markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>Ayush Patel – Portfolio</title>
   </head>
-  <body class="bg-gray-50 text-gray-800 font-sans">
+  <body class="bg-gradient-to-br from-sky-50 via-white to-indigo-50 text-gray-800 font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "framer-motion": "^12.19.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^8.0.7"
   },
   "devDependencies": {
     "@types/node": "^24.0.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,8 @@ import Chatbot from './components/Chatbot';
 
 export default function App() {
   return (
-    <div className="font-sans text-gray-800 bg-gradient-to-b from-gray-50 to-white min-h-screen">
-      <main className="max-w-5xl mx-auto px-6 pt-12 pb-32">
+    <div className="font-sans text-gray-800 min-h-screen">
+      <main className="max-w-4xl mx-auto px-6 py-16 space-y-20 bg-white/80 backdrop-blur-lg rounded-3xl shadow-2xl">
         <About />
         <Projects />
         <Contact />

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import ReactMarkdown from 'react-markdown';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';
@@ -128,17 +129,37 @@ export default function Chatbot() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.3 }}
-            className="fixed bottom-20 right-6 w-80 max-h-[32rem] bg-white border border-gray-200 rounded-xl shadow-xl flex flex-col p-4"
+            className="fixed bottom-20 right-6 w-80 max-h-[32rem] bg-white/90 backdrop-blur-md border border-gray-200 rounded-xl shadow-2xl flex flex-col p-4"
           >
             <div className="flex-1 space-y-2 overflow-y-auto mb-2">
               {messages.slice(1).map((msg, idx) => (
                 <div
                   key={idx}
-                  className={`p-3 rounded ${
-                    msg.role === 'user' ? 'bg-blue-100 text-right' : 'bg-gray-100 text-left'
+                  className={`p-3 rounded-md shadow ${
+                    msg.role === 'user' ? 'bg-blue-100/80 text-right' : 'bg-gray-100/80 text-left'
                   }`}
                 >
-                  <span>{msg.content}</span>
+                  <ReactMarkdown
+                    className="text-sm break-words whitespace-pre-wrap"
+                    components={{
+                      a: ({node, ...props}) => (
+                        <a
+                          {...props}
+                          className="text-blue-600 underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      ),
+                      ul: ({node, ...props}) => (
+                        <ul className="list-disc pl-5" {...props} />
+                      ),
+                      ol: ({node, ...props}) => (
+                        <ol className="list-decimal pl-5" {...props} />
+                      ),
+                    }}
+                  >
+                    {msg.content}
+                  </ReactMarkdown>
                 </div>
               ))}
               <div ref={messagesEndRef} />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,15 +2,15 @@ import { motion } from 'framer-motion';
 
 export const About = () => (
   <motion.section
-    className="mb-20"
+    className="mb-16 p-8 bg-white/90 rounded-2xl shadow-lg"
     id="about"
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
     transition={{ duration: 0.6 }}
   >
-    <h1 className="text-4xl font-bold mb-4">Hi, I'm Ayush Patel 👋</h1>
-    <p className="text-lg leading-relaxed">
+    <h1 className="text-5xl font-extrabold mb-6 text-indigo-700">Hi, I'm Ayush Patel 👋</h1>
+    <p className="text-lg leading-relaxed text-gray-700">
       I'm a data scientist passionate about turning complex data into actionable insights. I’ve worked with education and commercial data, built forecasting models, visual dashboards, and love uncovering hidden truths within data. My journey includes projects in fraud detection, job ad classification, and more — all available on my GitHub.
     </p>
   </motion.section>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -2,14 +2,15 @@ import { motion } from 'framer-motion';
 
 export const Contact = () => (
   <motion.section
+    className="p-8 bg-white/90 rounded-2xl shadow-lg"
     id="contact"
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
     transition={{ duration: 0.6 }}
   >
-    <h2 className="text-3xl font-semibold mb-4">Contact</h2>
-    <p>📧 <a href="mailto:ayushkp38@gmail.com" className="underline text-blue-600">ayushkp38@gmail.com</a></p>
-    <p>🔗 <a href="https://github.com/ayushpatel2002" className="underline text-blue-600">GitHub</a> | <a href="https://linkedin.com/in/ayushkpatel" className="underline text-blue-600">LinkedIn</a></p>
+    <h2 className="text-4xl font-bold mb-6 text-indigo-700">Contact</h2>
+    <p className="text-gray-700">📧 <a href="mailto:ayushkp38@gmail.com" className="underline text-blue-600">ayushkp38@gmail.com</a></p>
+    <p className="text-gray-700">🔗 <a href="https://github.com/ayushpatel2002" className="underline text-blue-600">GitHub</a> | <a href="https://linkedin.com/in/ayushkpatel" className="underline text-blue-600">LinkedIn</a></p>
   </motion.section>
 );

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -2,15 +2,15 @@ import { motion } from 'framer-motion';
 
 export const Projects = () => (
   <motion.section
-    className="mb-20"
+    className="mb-16 p-8 bg-white/90 rounded-2xl shadow-lg"
     id="projects"
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
     transition={{ duration: 0.6 }}
   >
-    <h2 className="text-3xl font-semibold mb-4">Projects</h2>
-    <ul className="space-y-6">
+    <h2 className="text-4xl font-bold mb-6 text-indigo-700">Projects</h2>
+    <ul className="space-y-4 text-gray-700">
       <li>
         <strong>Stack Exchange Modeling (Python):</strong> Modeled user behavior using Scikit-learn on Stack Exchange posts.
       </li>


### PR DESCRIPTION
## Summary
- add `react-markdown` dependency
- render bot messages using `ReactMarkdown`
- style markdown content so links and lists work inside chat bubbles
- apply a light gradient background
- refresh section styling for a more polished portfolio layout

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686710bb5c20832186f30613a1fa9eb2