### PR TITLE
Enhance portfolio layout with hero and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Portfolio of Ayush Patel, data scientist and full-stack AI developer" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet" />
     <title>Ayush Patel – Portfolio</title>
   </head>
-  <body class="bg-gray-50 text-gray-800 font-sans">
+  <body class="bg-gradient-to-br from-sky-50 via-white to-indigo-50 text-gray-800 dark:text-gray-100 dark:bg-gray-900 font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "dependencies": {
     "framer-motion": "^12.19.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^8.0.7",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Navbar from './components/Navbar';
+import Footer from './components/Footer';
+import Chatbot from './components/Chatbot';
+import { Hero } from './pages/Hero';
 import { About } from './pages/About';
 import { Projects } from './pages/Projects';
+import { Skills } from './pages/Skills';
 import { Contact } from './pages/Contact';
-import Chatbot from './components/Chatbot';
 
 export default function App() {
+  const [dark, setDark] = useState(false);
+  const toggleDark = () => setDark((d) => !d);
+
   return (
-    <div className="font-sans text-gray-800 bg-gradient-to-b from-gray-50 to-white min-h-screen">
-      <main className="max-w-5xl mx-auto px-6 pt-12 pb-32">
-        <About />
-        <Projects />
-        <Contact />
-      </main>
-      <Chatbot />
+    <div className={dark ? 'dark' : ''}>
+      <div className="font-sans text-gray-800 dark:text-gray-100 min-h-screen" >
+        <Navbar toggleDark={toggleDark} dark={dark} />
+        <main className="max-w-5xl mx-auto px-6 py-16 space-y-20">
+          <Hero />
+          <About />
+          <Projects />
+          <Skills />
+          <Contact />
+        </main>
+        <Footer />
+        <Chatbot />
+      </div>
     </div>
   );
 }

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import ReactMarkdown from 'react-markdown';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';
@@ -128,17 +129,39 @@ export default function Chatbot() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.3 }}
-            className="fixed bottom-20 right-6 w-80 max-h-[32rem] bg-white border border-gray-200 rounded-xl shadow-xl flex flex-col p-4"
+            className="fixed bottom-20 right-6 w-80 max-h-[32rem] bg-white/90 dark:bg-gray-800/90 backdrop-blur-md border border-gray-200 rounded-xl shadow-2xl flex flex-col p-4"
           >
             <div className="flex-1 space-y-2 overflow-y-auto mb-2">
               {messages.slice(1).map((msg, idx) => (
                 <div
                   key={idx}
-                  className={`p-3 rounded ${
-                    msg.role === 'user' ? 'bg-blue-100 text-right' : 'bg-gray-100 text-left'
+                  className={`p-3 rounded-md shadow ${
+                    msg.role === 'user'
+                      ? 'bg-blue-100/80 text-right'
+                      : 'bg-gray-100/80 dark:bg-gray-700/80 text-left'
                   }`}
                 >
-                  <span>{msg.content}</span>
+                  <ReactMarkdown
+                    className="text-sm break-words whitespace-pre-wrap"
+                    components={{
+                      a: ({node, ...props}) => (
+                        <a
+                          {...props}
+                          className="text-blue-600 underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      ),
+                      ul: ({node, ...props}) => (
+                        <ul className="list-disc pl-5" {...props} />
+                      ),
+                      ol: ({node, ...props}) => (
+                        <ol className="list-decimal pl-5" {...props} />
+                      ),
+                    }}
+                  >
+                    {msg.content}
+                  </ReactMarkdown>
                 </div>
               ))}
               <div ref={messagesEndRef} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+      © {new Date().getFullYear()} Ayush Patel. All rights reserved.
+    </footer>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+  toggleDark: () => void;
+  dark: boolean;
+}
+
+export default function Navbar({ toggleDark, dark }: Props) {
+  return (
+    <nav className="fixed top-0 left-0 right-0 bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow z-50">
+      <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
+        <a href="#hero" className="font-bold text-indigo-700 dark:text-indigo-300">Ayush Patel</a>
+        <div className="space-x-4 hidden sm:block">
+          <a href="#about" className="hover:text-indigo-600 dark:hover:text-indigo-400">About</a>
+          <a href="#projects" className="hover:text-indigo-600 dark:hover:text-indigo-400">Projects</a>
+          <a href="#skills" className="hover:text-indigo-600 dark:hover:text-indigo-400">Skills</a>
+          <a href="#contact" className="hover:text-indigo-600 dark:hover:text-indigo-400">Contact</a>
+          <button onClick={toggleDark} className="ml-4 px-2 py-1 border rounded text-sm">
+            {dark ? 'Light' : 'Dark'}
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Code+Pro:wght@400;600&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,15 +2,15 @@ import { motion } from 'framer-motion';
 
 export const About = () => (
   <motion.section
-    className="mb-20"
+    className="mb-16 p-8 bg-white/90 dark:bg-gray-800/90 rounded-2xl shadow-lg"
     id="about"
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
     transition={{ duration: 0.6 }}
   >
-    <h1 className="text-4xl font-bold mb-4">Hi, I'm Ayush Patel 👋</h1>
-    <p className="text-lg leading-relaxed">
+    <h1 className="text-5xl font-extrabold mb-6 text-indigo-700 dark:text-indigo-300">Hi, I'm Ayush Patel 👋</h1>
+    <p className="text-lg leading-relaxed text-gray-700 dark:text-gray-300">
       I'm a data scientist passionate about turning complex data into actionable insights. I’ve worked with education and commercial data, built forecasting models, visual dashboards, and love uncovering hidden truths within data. My journey includes projects in fraud detection, job ad classification, and more — all available on my GitHub.
     </p>
   </motion.section>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -2,14 +2,15 @@ import { motion } from 'framer-motion';
 
 export const Contact = () => (
   <motion.section
+    className="p-8 bg-white/90 dark:bg-gray-800/90 rounded-2xl shadow-lg"
     id="contact"
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
     transition={{ duration: 0.6 }}
   >
-    <h2 className="text-3xl font-semibold mb-4">Contact</h2>
-    <p>📧 <a href="mailto:ayushkp38@gmail.com" className="underline text-blue-600">ayushkp38@gmail.com</a></p>
-    <p>🔗 <a href="https://github.com/ayushpatel2002" className="underline text-blue-600">GitHub</a> | <a href="https://linkedin.com/in/ayushkpatel" className="underline text-blue-600">LinkedIn</a></p>
+    <h2 className="text-4xl font-bold mb-6 text-indigo-700 dark:text-indigo-300">Contact</h2>
+    <p className="text-gray-700 dark:text-gray-300">📧 <a href="mailto:ayushkp38@gmail.com" className="underline text-blue-600">ayushkp38@gmail.com</a></p>
+    <p className="text-gray-700 dark:text-gray-300">🔗 <a href="https://github.com/ayushpatel2002" className="underline text-blue-600">GitHub</a> | <a href="https://linkedin.com/in/ayushkpatel" className="underline text-blue-600">LinkedIn</a></p>
   </motion.section>
 );

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -1,0 +1,31 @@
+import { motion } from 'framer-motion';
+
+export const Hero = () => (
+  <section
+    id="hero"
+    className="min-h-screen flex flex-col justify-center items-center text-center space-y-6 relative overflow-hidden"
+  >
+    <motion.h1
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      className="text-6xl font-extrabold text-indigo-700 mb-4"
+    >
+      Turning Data into Impact
+    </motion.h1>
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.6 }} className="flex gap-4">
+      <a
+        href="/Documents/resume.pdf"
+        className="px-5 py-3 bg-indigo-600 text-white rounded shadow hover:bg-indigo-700"
+      >
+        Download Resume
+      </a>
+      <a
+        href="#projects"
+        className="px-5 py-3 border border-indigo-600 text-indigo-600 rounded hover:bg-indigo-50"
+      >
+        Explore Projects
+      </a>
+    </motion.div>
+  </section>
+);

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -2,15 +2,15 @@ import { motion } from 'framer-motion';
 
 export const Projects = () => (
   <motion.section
-    className="mb-20"
+    className="mb-16 p-8 bg-white/90 dark:bg-gray-800/90 rounded-2xl shadow-lg"
     id="projects"
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
     transition={{ duration: 0.6 }}
   >
-    <h2 className="text-3xl font-semibold mb-4">Projects</h2>
-    <ul className="space-y-6">
+    <h2 className="text-4xl font-bold mb-6 text-indigo-700 dark:text-indigo-300">Projects</h2>
+    <ul className="space-y-4 text-gray-700 dark:text-gray-300">
       <li>
         <strong>Stack Exchange Modeling (Python):</strong> Modeled user behavior using Scikit-learn on Stack Exchange posts.
       </li>

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Radar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
+
+export const Skills = () => {
+  const data = {
+    labels: ['Data Science', 'Full Stack', 'Tools', 'Cloud'],
+    datasets: [
+      {
+        label: 'Proficiency',
+        data: [90, 80, 75, 60],
+        backgroundColor: 'rgba(79,70,229,0.2)',
+        borderColor: '#4f46e5',
+        borderWidth: 2,
+      },
+    ],
+  };
+
+  const options = {
+    scales: {
+      r: {
+        beginAtZero: true,
+        ticks: { display: false },
+      },
+    },
+    plugins: { legend: { display: false } },
+    responsive: true,
+  } as const;
+
+  return (
+    <section id="skills" className="mb-16 p-8 bg-white/90 dark:bg-gray-800/90 rounded-2xl shadow-lg">
+      <h2 className="text-4xl font-bold mb-6 text-indigo-700 dark:text-indigo-300">Skills</h2>
+      <div className="max-w-sm mx-auto">
+        <Radar data={data} options={options} />
+      </div>
+    </section>
+  );
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,13 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
+        mono: ['"Source Code Pro"', ...defaultTheme.fontFamily.mono],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add radar chart skills section and hero banner
- create a navbar, footer, and dark-mode toggle
- wire new components in App
- style chatbot and sections for dark theme support
- configure Tailwind for Source Code Pro fonts

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686710bb5c20832186f30613a1fa9eb2