### PR TITLE
Add LangChain RAG scripts for OpenRouter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ data/train.json
 
 # Prevent accidentally committing large files or secrets
 openrouter_key.txt
+vectorstore/

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,57 @@
+"""Dataset ingestion script for portfolio RAG pipeline.
+
+This script loads entries from ``Data/PersonalPortfolioDataset.json``,
+splits them into chunks, generates embeddings using ``sentence-transformers``
+and stores them in a local Chroma vector store under ``./vectorstore``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from langchain.docstore.document import Document
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Chroma
+from langchain.embeddings import HuggingFaceEmbeddings
+
+
+DATA_PATH = Path("Data/PersonalPortfolioDataset.json")
+VECTOR_DIR = Path("vectorstore")
+
+
+def load_entries() -> list[dict]:
+    """Load portfolio entries from the JSON dataset."""
+    with open(DATA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_documents(entries: list[dict]) -> list[Document]:
+    """Create LangChain documents from dataset entries."""
+    docs = []
+    for entry in entries:
+        text = f"{entry.get('title', '')}\n{entry.get('summary', '')}\n{entry.get('content', '')}"
+        docs.append(
+            Document(page_content=text, metadata={"type": entry.get("type"), "title": entry.get("title")})
+        )
+    return docs
+
+
+def ingest() -> None:
+    """Main ingestion routine."""
+    entries = load_entries()
+    documents = build_documents(entries)
+
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    docs = splitter.split_documents(documents)
+
+    embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+    VECTOR_DIR.mkdir(exist_ok=True)
+    Chroma.from_documents(documents=docs, embedding=embeddings, persist_directory=str(VECTOR_DIR))
+    print(f"Ingested {len(docs)} chunks into {VECTOR_DIR}/")
+
+
+if __name__ == "__main__":
+    ingest()
+

--- a/query.py
+++ b/query.py
@@ -1,0 +1,88 @@
+"""CLI for querying the portfolio RAG index using OpenRouter."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import List
+
+import openrouter
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import Chroma
+
+
+VECTOR_DIR = Path("vectorstore")
+
+
+def load_api_key() -> str | None:
+    """Load API key from environment or .env file."""
+    key = os.getenv("OPENROUTER_API_KEY")
+    if key:
+        return key
+
+    env_path = Path(".env")
+    if env_path.exists():
+        with open(env_path) as f:
+            for line in f:
+                if line.startswith("OPENROUTER_API_KEY"):
+                    _, val = line.strip().split("=", 1)
+                    return val
+    return None
+
+
+def load_vectorstore() -> Chroma:
+    """Load the persisted Chroma vector store."""
+    embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    return Chroma(persist_directory=str(VECTOR_DIR), embedding_function=embeddings)
+
+
+def query_index(question: str, top_k: int = 3) -> str:
+    """Retrieve similar chunks and ask Mistral 7B via OpenRouter."""
+    store = load_vectorstore()
+    docs = store.similarity_search(question, k=top_k)
+    context = "\n\n".join(d.page_content for d in docs)
+
+    api_key = load_api_key()
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY not provided")
+
+    client = openrouter.Client(api_key=api_key)
+    messages = [
+        {
+            "role": "system",
+            "content": "You are Ayush Patel's portfolio assistant. Use the provided context to answer questions.",
+        },
+        {
+            "role": "user",
+            "content": f"Context:\n{context}\n\nQuestion: {question}",
+        },
+    ]
+    resp = client.chat.completions.create(model="mistralai/mistral-7b-instruct", messages=messages)
+    return resp.choices[0].message.content
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query the portfolio RAG index")
+    parser.add_argument("question", nargs="?", help="User question")
+    parser.add_argument("--top_k", type=int, default=3, help="Number of chunks to retrieve")
+    args = parser.parse_args()
+
+    if not args.question:
+        example_questions = [
+            "What is Ayush's experience with NLP?",
+            "Describe Ayush's forecasting project.",
+            "List Ayush's core skills.",
+        ]
+        print("Example questions:")
+        for q in example_questions:
+            print(f" - {q}")
+        return
+
+    answer = query_index(args.question, top_k=args.top_k)
+    print(answer)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+langchain
+chromadb
+sentence-transformers
+openrouter


### PR DESCRIPTION
## Summary
- ignore `vectorstore/` directory
- create `ingest.py` to build a Chroma index over the portfolio JSON data
- create `query.py` CLI using OpenRouter's Mistral 7B model
- document Python dependencies

## Testing
- `python ingest.py` *(fails: No module named 'langchain')*
- `python query.py "What is Ayush's experience with NLP?"` *(fails: No module named 'openrouter')*

------
https://chatgpt.com/codex/tasks/task_e_6868e1b73af08321ab506151c6819c15