### PR TITLE
Dark mode redesign with lazy-loaded API

### DIFF
--- a/api/ask.ts
+++ b/api/ask.ts
@@ -1,0 +1,55 @@
+export const config = {
+  runtime: 'edge',
+};
+
+export default async function handler(request: Request): Promise<Response> {
+  try {
+    const { question } = await request.json();
+    if (!question) {
+      return new Response(
+        JSON.stringify({ error: 'No question provided.' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Lazy-load heavy modules only when needed
+    const [{ default: OpenAI }, fs] = await Promise.all([
+      import('openai').then((m) => m.default || m),
+      import('fs/promises'),
+    ]);
+    const path = (await import('path')).default;
+
+    const dataPath = path.join(process.cwd(), 'public', 'PersonalPortfolioDataset.json');
+    const raw = await fs.readFile(dataPath, 'utf-8');
+    const dataset = JSON.parse(raw) as Array<{ title: string; summary: string; content: string }>;
+    const context = dataset
+      .map((d) => `${d.title}\n${d.summary}\n${d.content}`)
+      .join('\n\n');
+
+    const openai = new OpenAI({ apiKey: process.env.OPENROUTER_API_KEY });
+
+    const completion = await openai.chat.completions.create({
+      model: 'mistralai/mistral-7b-instruct',
+      messages: [
+        {
+          role: 'system',
+          content: "You are Ayush Patel's portfolio assistant. Use the provided context to answer questions.",
+        },
+        { role: 'user', content: `Context:\n${context}\n\nQuestion: ${question}` },
+      ],
+      temperature: 0.7,
+    });
+
+    const answer = completion.choices?.[0]?.message?.content?.trim() || '';
+
+    return new Response(JSON.stringify({ answer }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('ask error', error);
+    return new Response(
+      JSON.stringify({ error: 'Server error. Please try again later.' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>Ayush Patel – Portfolio</title>
   </head>
-  <body class="bg-gradient-to-br from-sky-50 via-white to-indigo-50 text-gray-800 font-sans">
+  <body class="bg-gray-900 text-gray-100 font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
   },
   "dependencies": {
     "@motionone/dom": "^10.18.0",
-    "@react-spring/web": "^10.0.1",
     "framer-motion": "^10.12.16",
+    "openai": "^4.33.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intersection-observer": "^9.16.0",
     "react-markdown": "^8.0.7"
   },
   "devDependencies": {

--- a/public/PersonalPortfolioDataset.json
+++ b/public/PersonalPortfolioDataset.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "project",
+    "title": "Forecasting Energy Use",
+    "summary": "Developed a time series model using R and Prophet to forecast energy consumption patterns.",
+    "content": "Ayush implemented a robust energy consumption forecasting pipeline using R and Facebook's Prophet library. The project involved preprocessing time series data, handling missing values, generating lag-based and rolling statistical features, and applying seasonality-based modeling. He conducted rigorous evaluation through cross-validation, resulting in improved forecasting accuracy across multiple regions. This project highlighted his strengths in statistical modeling, trend detection, and predictive analytics."
+  },
+  {
+    "type": "project",
+    "title": "NLP-Based Job Advertisement Classification",
+    "summary": "Built a Flask-based NLP classifier that categorizes job ads based on sector and intent.",
+    "content": "Ayush led the development of a machine learning pipeline to classify job advertisements using NLP techniques. The process involved tokenization, stopword filtering, TF-IDF vectorization, and Logistic Regression. He also integrated the model into a Flask web app with real-time input processing. This university project demonstrated his understanding of natural language processing, model serving, and UI/UX data interaction. The classifier delivered >85% accuracy on labeled data and served as a recommendation engine."
+  },
+  {
+    "type": "project",
+    "title": "Equity Reporting with Power BI",
+    "summary": "Built dynamic dashboards for NT Department of Education to support equity-driven reporting.",
+    "content": "In his current role as a Data Analyst, Ayush developed advanced Power BI dashboards with interactive filters, multi-year comparison views, and KPI indicators. These dashboards enabled service quality monitoring across assessment cycles and domains. By combining DAX-driven measures with SQL and R-based preprocessing, he delivered insights that influenced resource allocation and equity strategies. The work required translating policy into metrics and enabled data transparency at executive levels."
+  },
+  {
+    "type": "internship",
+    "title": "Data Lakehouse Intern – Digicor",
+    "summary": "Engineered Spark-based ETL pipelines and streamlined internal data workflows.",
+    "content": "As a Data Lakehouse Intern, Ayush designed scalable ETL pipelines using Apache Spark and Delta Lake. He transformed raw datasets into analytical tables, applied metadata schemas, and performed data validation through SQL. The optimized workflows improved reporting speed by 30%. He also built Python utilities and integrated REST APIs to automate dataset access. His work laid the groundwork for a modular, fast-refresh reporting layer and improved collaboration across technical and business teams."
+  },
+  {
+    "type": "achievement",
+    "title": "AI Hackathon – People's Choice Winner",
+    "summary": "Won People's Choice Award for AI-powered student support web app.",
+    "content": "Ayush and his team built a sentiment-aware AI platform to assist students based on emotional signals and feedback. It used NLP sentiment analysis to trigger personalized resources. Ayush designed the data ingestion, model flow, and analytics dashboard components. The solution was praised for real-time usefulness and data ethics, securing top votes in the competition. This showcased his ability to build complete AI solutions in high-pressure, collaborative environments."
+  },
+  {
+    "type": "skills",
+    "title": "Core Technical & Analytical Skills",
+    "summary": "End-to-end experience with data engineering, analysis, visualization, and deployment.",
+    "content": "Ayush has a strong foundation in Python, R, SQL, and JavaScript. He is fluent with libraries and tools such as Pandas, scikit-learn, Prophet, Power BI, Apache Spark, Flask, and TailwindCSS. His expertise spans data wrangling, statistical modeling, forecasting, NLP, data lakehouse architecture, and full-stack analytics dashboards. He is comfortable with Git, REST APIs, data governance, and stakeholder alignment. Additionally, he has a working understanding of AWS and Azure AI fundamentals."
+  },
+  {
+    "type": "about",
+    "title": "About Ayush Patel",
+    "summary": "Data scientist passionate about insights, equity, and real-world applications.",
+    "content": "Ayush Patel is a data professional driven by a desire to use data for impact. With a Bachelor of IT (Data Science major) from RMIT, a 3.5 GPA, and a WAM of 85, he brings analytical rigor, engineering discipline, and human-centered thinking to every project. He thrives in both technical build phases and stakeholder-facing roles, often acting as a translator between data and decision-makers. His work touches education, operations, and AI development. He currently works as a Data Analyst at the Northern Territory Department of Education, where he develops Power BI dashboards, performs data preprocessing using R and SQL, and delivers equity-focused insights to support executive reporting and resource planning. He continuously learns, contributes to GitHub, and builds meaningful, scalable solutions."
+  },
+  {
+    "type": "work",
+    "title": "Data Analyst – NT Department of Education",
+    "summary": "Delivering equity-driven insights and operational dashboards for government education services.",
+    "content": "Ayush works as a Data Analyst at the Northern Territory Department of Education, where he designs and builds Power BI dashboards that help monitor service quality across regions and years. His work involves transforming raw data using R and SQL, integrating datasets, and creating DAX-driven metrics to reflect policy-relevant outcomes. He translates complex regulatory requirements into actionable KPIs, enabling senior decision-makers to make informed, equity-focused choices. His work supports reporting on early childhood education, staff qualifications, and service accessibility. He regularly collaborates across departments, ensuring that data solutions align with real-world education challenges."
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,13 @@ import Chatbot from './components/Chatbot';
 
 export default function App() {
   return (
-    <div className="font-sans text-gray-800 bg-gradient-to-b from-gray-50 to-white min-h-screen">
-      <main className="max-w-5xl mx-auto px-6 py-16 space-y-20 bg-white/80 backdrop-blur-lg rounded-3xl shadow-2xl">
+    <div className="font-sans bg-gray-900 text-gray-100 min-h-screen">
+      <main className="max-w-5xl mx-auto px-4 py-16 space-y-20">
         <About />
         <Projects />
+        <Chatbot />
         <Contact />
       </main>
-      <Chatbot />
     </div>
   );
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,23 +1,24 @@
-import { useSpring, animated } from '@react-spring/web';
+import { motion } from 'framer-motion';
 
 export const About = () => {
-  const props = useSpring({ from: { opacity: 0, transform: 'translateY(20px)' }, to: { opacity: 1, transform: 'translateY(0px)' }, config: { duration: 600 } });
-
   return (
-    <animated.section
-      className="mb-16 p-8 bg-white/90 rounded-2xl shadow-lg"
+    <motion.section
+      className="mb-16 p-8 bg-gray-800 rounded-2xl shadow-xl"
       id="about"
-      style={props}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
     >
-      <h1 className="text-5xl font-extrabold mb-6 text-indigo-700">
+      <h1 className="text-5xl font-extrabold mb-6 text-indigo-400">
         Hi, I'm Ayush Patel 👋
       </h1>
-      <p className="text-lg leading-relaxed text-gray-700">
+      <p className="text-lg leading-relaxed text-gray-300">
         I'm a data scientist passionate about turning complex data into actionable insights.
-        I’ve worked with education and commercial data, built forecasting models, visual dashboards, 
-        and love uncovering hidden truths within data. My journey includes projects in fraud detection, 
+        I’ve worked with education and commercial data, built forecasting models, visual dashboards,
+        and love uncovering hidden truths within data. My journey includes projects in fraud detection,
         job ad classification, and more — all available on my GitHub.
       </p>
-    </animated.section>
+    </motion.section>
   );
 };

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,31 +1,32 @@
-import { useSpring, animated } from '@react-spring/web';
+import { motion } from 'framer-motion';
 
 export const Contact = () => {
-  const styles = useSpring({
-    from: { opacity: 0, transform: 'translateY(20px)' },
-    to: { opacity: 1, transform: 'translateY(0px)' },
-    config: { duration: 600 },
-  });
-
   return (
-    <animated.section style={styles} className="p-8 bg-white/90 rounded-2xl shadow-lg" id="contact">
-      <h2 className="text-4xl font-bold mb-6 text-indigo-700">Contact</h2>
-      <p className="text-gray-700 mb-2">
+    <motion.section
+      id="contact"
+      className="p-8 bg-gray-800 rounded-2xl shadow-xl"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+    >
+      <h2 className="text-4xl font-bold mb-6 text-indigo-400">Contact</h2>
+      <p className="text-gray-300 mb-2">
         📧{' '}
         <a
           href="mailto:ayushkp38@gmail.com"
-          className="underline text-blue-600 hover:text-blue-800"
+          className="underline text-blue-300 hover:text-blue-400"
         >
           ayushkp38@gmail.com
         </a>
       </p>
-      <p className="text-gray-700">
+      <p className="text-gray-300">
         🔗{' '}
         <a
           href="https://github.com/ayushpatel2002"
           target="_blank"
           rel="noopener noreferrer"
-          className="underline text-blue-600 hover:text-blue-800"
+          className="underline text-blue-300 hover:text-blue-400"
         >
           GitHub
         </a>{' '}
@@ -34,11 +35,11 @@ export const Contact = () => {
           href="https://linkedin.com/in/ayushkpatel"
           target="_blank"
           rel="noopener noreferrer"
-          className="underline text-blue-600 hover:text-blue-800"
+          className="underline text-blue-300 hover:text-blue-400"
         >
           LinkedIn
         </a>
       </p>
-    </animated.section>
+    </motion.section>
   );
 };

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,4 +1,4 @@
-import { useSpring, animated } from '@react-spring/web';
+import { motion } from 'framer-motion';
 
 const projectData = [
   {
@@ -39,24 +39,32 @@ const projectData = [
 ];
 
 export const Projects = () => (
-  <animated.section
+  <motion.section
     id="projects"
-    className="mb-16 p-8 bg-white/90 rounded-2xl shadow-lg"
+    className="mb-16 p-8 bg-gray-800 rounded-2xl shadow-xl"
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.6 }}
   >
-    <h2 className="text-4xl font-bold mb-8 text-indigo-700">Projects</h2>
+    <h2 className="text-4xl font-bold mb-8 text-indigo-400">Projects</h2>
     <div className="grid gap-6 md:grid-cols-2">
       {projectData.map((project, idx) => (
-        <animated.div
+        <motion.div
           key={idx}
-          className="bg-white border border-gray-200 rounded-xl p-6 shadow hover:shadow-lg transition"
+          className="bg-gray-700 rounded-xl p-6 shadow hover:shadow-lg transition"
+          initial={{ opacity: 0, y: 10 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: idx * 0.1 }}
         >
-          <h3 className="text-xl font-semibold text-gray-800 mb-2">{project.title}</h3>
-          <p className="text-gray-600 text-sm mb-3">{project.description}</p>
+          <h3 className="text-xl font-semibold text-gray-100 mb-2">{project.title}</h3>
+          <p className="text-gray-300 text-sm mb-3">{project.description}</p>
           <div className="flex flex-wrap gap-2 mb-3">
             {project.stack.map((tech, i) => (
               <span
                 key={i}
-                className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full font-medium"
+                className="text-xs bg-blue-500/20 text-blue-200 px-2 py-1 rounded-full font-medium"
               >
                 {tech}
               </span>
@@ -67,13 +75,13 @@ export const Projects = () => (
               href={project.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm text-blue-600 hover:underline"
+              className="text-sm text-blue-300 hover:underline"
             >
               View on GitHub →
             </a>
           )}
-        </animated.div>
+        </motion.div>
       ))}
     </div>
-  </animated.section>
+  </motion.section>
 );


### PR DESCRIPTION
## Summary
- add new `/api/ask` route with dynamic imports and load dataset from `/public`
- move dataset to `public/`
- redesign portfolio to dark theme
- integrate a new chatbot section using `framer-motion`
- animate About, Projects and Contact sections
- drop unused packages in `package.json`

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68696b21c2a88321b17dbcfc51f6e150