### PR TITLE
Use env var for backend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for the portfolio project
+VITE_BACKEND_URL=http://localhost:8080
+OPENROUTER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This repository includes a lightweight retrieval-augmented generation (RAG) pipe
    ```bash
    echo "OPENROUTER_API_KEY=sk-..." > .env
    ```
+4. (Optional) specify the backend URL used by the React app:
+   ```bash
+   echo "VITE_BACKEND_URL=http://localhost:8080" >> .env
+   ```
 
 ## Ingestion
 Run the ingestion script to build the local vector store:

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -68,7 +68,8 @@ export default function Chatbot() {
     setIsLoading(true);
 
     try {
-      const response = await fetch('http://localhost:8080/ask', {
+      const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
+      const response = await fetch(`${backendUrl}/ask`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- parametrize backend URL in the Chatbot component so deployments can target a remote FastAPI server
- document backend environment variables
- provide `.env.example` with the required variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ce091df548321bb8383bbf6356497