### PR TITLE
Fix backend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Environment variables for the portfolio project
-VITE_BACKEND_URL=http://localhost:8080
+VITE_BACKEND_URL=https://personal-portfolio-production-b064.up.railway.app
 OPENROUTER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository includes a lightweight retrieval-augmented generation (RAG) pipe
    ```
 4. (Optional) specify the backend URL used by the React app:
    ```bash
-   echo "VITE_BACKEND_URL=http://localhost:8080" >> .env
+   echo "VITE_BACKEND_URL=https://personal-portfolio-production-b064.up.railway.app" >> .env
    ```
 
 ## Ingestion

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -67,7 +67,9 @@ export default function Chatbot() {
     setInput('');
     setIsLoading(true);
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
+    const backendUrl =
+      import.meta.env.VITE_BACKEND_URL ||
+      'https://personal-portfolio-production-b064.up.railway.app';
 
     try {
       const response = await fetch(`${backendUrl}/ask`, {


### PR DESCRIPTION
## Summary
- set default backend URL to the Railway deployment
- update sample environment variable and README instructions

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686dc7c2ec788321b3df1d5046f9e8ff