### PR TITLE
Enhance UI styling and rename chatbot

### DIFF
--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -46,7 +46,7 @@ export default function Chatbot() {
         ...prev,
         {
           role: 'assistant',
-          content: "👋 Hi! I'm AyushBot — your AI guide to Ayush Patel’s portfolio. Ask me about his projects, skills, or experience!",
+          content: "👋 Hi! I'm Bimb — your AI guide to Ayush Patel’s portfolio. Ask me about his projects, skills, or experience!",
         },
       ]);
     }
@@ -133,12 +133,12 @@ export default function Chatbot() {
       </style>
 
       <button
-        className="fixed bottom-6 right-6 z-50 bg-gradient-to-r from-indigo-500 via-purple-600 to-pink-500 text-white px-5 py-3 rounded-full shadow-2xl flex items-center space-x-2 hover:scale-110 hover:shadow-2xl transition-transform duration-300 group"
+        className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-50 bg-gradient-to-r from-indigo-500 via-purple-600 to-pink-500 text-white px-5 py-3 rounded-full shadow-2xl flex items-center space-x-2 hover:scale-110 hover:shadow-2xl transition-transform duration-300 group"
         onClick={() => setIsOpen(true)}
       >
         <span className="text-sm font-semibold flex items-center space-x-1">
           🤖
-          <span className="group-hover:animate-pulse">Ask AyushBot</span>
+          <span className="group-hover:animate-pulse">Ask Bimb</span>
         </span>
         <span className="bg-white text-purple-700 text-xs font-bold px-2 py-1 rounded shadow-md">AI</span>
         <span className="w-2 h-2 rounded-full bg-green-400 animate-ping ml-1"></span>
@@ -147,11 +147,11 @@ export default function Chatbot() {
       {isOpen && (
         <animated.div
           style={slideIn}
-          className="fixed top-0 right-0 w-full max-w-md h-screen bg-gray-900 border-l border-gray-700 shadow-2xl z-50 flex flex-col"
+          className="fixed top-0 right-0 w-full sm:max-w-md h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 animate-gradient border-l border-gray-700 shadow-2xl z-50 flex flex-col"
         >
             <div className="p-4 border-b border-gray-700 flex justify-between items-center">
               <div>
-                <h2 className="text-lg font-semibold text-indigo-300">👋 I’m AyushBot</h2>
+                <h2 className="text-lg font-semibold text-indigo-300">👋 I’m Bimb</h2>
                 <p className="text-xs text-gray-300">Ask me anything about Ayush’s projects, skills, or experience – Powered by AI, trained on his real portfolio.</p>
               </div>
               <button

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  @keyframes gradient-move {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+  }
+  .animate-gradient {
+    background-size: 200% 200%;
+    animation: gradient-move 8s ease-in-out infinite;
+  }
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -16,7 +16,7 @@ export const About = () => {
       id="about"
       style={slideIn}
     >
-      <h1 className="text-5xl font-extrabold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient-x [background-size:200%_200%] [animation-duration:4s] [animation-timing-function:ease-in-out] [animation-iteration-count:infinite]">
+      <h1 className="text-5xl font-extrabold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient">
         Everything Ayush Patel — Ideas, Insights & Impact.
       </h1>
       <p className="text-lg leading-relaxed text-zinc-300">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -16,7 +16,7 @@ export const Contact = () => {
       className="relative p-8 bg-[#1A1A2E]/90 text-[#EAEAEA] rounded-2xl shadow-xl border border-purple-900/30 backdrop-blur-md overflow-hidden"
       id="contact"
     >
-    <h2 className="text-4xl font-bold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient-x [background-size:200%_200%] [animation-duration:4s]">
+    <h2 className="text-4xl font-bold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient">
       Let’s Connect
     </h2>
     <p className="mb-2">

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -54,7 +54,7 @@ export const Projects = () => {
       id="projects"
       className="relative mb-16 p-8 bg-[#1e1e2f]/90 text-gray-100 rounded-2xl shadow-xl border border-purple-900/30 backdrop-blur-md overflow-hidden"
     >
-    <h2 className="text-4xl font-bold mb-8 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient-x [background-size:200%_200%] [animation-duration:4s]">
+    <h2 className="text-4xl font-bold mb-8 bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient">
       Featured Projects
     </h2>
     <div className="grid gap-6 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- add reusable `animate-gradient` utility with smooth color movement
- use new animation on headings
- rename the chatbot to **Bimb** and polish its layout for mobile

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686fc687845483218ae3bb67e3480e63