### PR TITLE
Refactor chatbot UI with Tailwind

### DIFF
--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useSpring, animated } from '@react-spring/web';
 import ReactMarkdown from 'react-markdown';
 
 interface Message {
@@ -52,10 +51,6 @@ export default function Chatbot() {
     }
   }, [isOpen]);
 
-  const slideIn = useSpring({
-    from: { transform: 'translateX(100%)' },
-    to: { transform: 'translateX(0%)' },
-  });
 
   const sendMessage = async (promptOverride?: string) => {
     const content = promptOverride || input.trim();
@@ -132,28 +127,24 @@ export default function Chatbot() {
         `}
       </style>
 
-      <button
-        className="fixed bottom-6 right-6 z-50 bg-gradient-to-r from-indigo-500 via-purple-600 to-pink-500 text-white px-5 py-3 rounded-xl shadow-2xl flex items-center space-x-2 hover:scale-110 hover:shadow-2xl transition-transform duration-300 group"
-        onClick={() => setIsOpen(true)}
-      >
-        <span className="text-sm font-semibold flex items-center space-x-1">
-          {/* <img src="Public/AR Logo.png" alt="AyushAI Logo" className="w-5 h-5 rounded" /> */}
-          <span className="group-hover:animate-pulse">Ask Bimb</span>
-        </span>
-        <span className="bg-white text-purple-700 text-xs font-bold px-2 py-1 rounded shadow-md">AI</span>
-        <span className="w-2 h-2 rounded-full bg-green-400 animate-ping ml-1"></span>
-      </button>
-
-      {isOpen && (
-        <animated.div
-          style={slideIn}
-          className="fixed top-0 right-0 w-full max-w-md h-screen bg-gray-900 border-l border-gray-700 shadow-2xl z-50 flex flex-col"
+      {!isOpen && (
+        <button
+          className="fixed bottom-6 right-6 z-50 rounded-full p-4 bg-gradient-to-r from-indigo-500 via-purple-600 to-pink-500 shadow-xl ring-2 ring-purple-400 hover:scale-110 transition-transform duration-300 ease-in-out animate-pulse"
+          onClick={() => setIsOpen(true)}
         >
-            <div className="p-4 border-b border-gray-700 flex justify-between items-center">
-              <div>
-                <h2 className="text-lg font-semibold text-indigo-300">👋 I’m Bimb</h2>
-                <p className="text-xs text-gray-300">Ask me anything about Ayush’s projects, skills, or experience – Powered by AI, trained on his real portfolio.</p>
+          <img src="/AR Logo.png" alt="Open chat" className="w-6 h-6" />
+        </button>
+      )}
+
+      <div
+        className={`fixed right-0 sm:top-0 bottom-0 w-full sm:max-w-md h-[50vh] sm:h-screen bg-gradient-to-b from-gray-900 via-gray-800 to-gray-900 border-l border-gray-700 drop-shadow-2xl z-50 flex flex-col transform transition-transform duration-300 ease-in-out rounded-l-3xl sm:rounded-none ${isOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none'}`}
+      >
+            <div className="p-4 border-b border-gray-700 flex justify-between items-center rounded-t-3xl sm:rounded-none">
+              <div className="flex items-center gap-2">
+                <img src="/AR Logo.png" alt="Bimb Logo" className="w-6 h-6" />
+                <h2 className="text-lg font-semibold text-indigo-300">I’m Bimb</h2>
               </div>
+              <p className="text-xs text-gray-300 flex-1 ml-2">Ask me anything about Ayush’s projects, skills, or experience – Powered by AI, trained on his real portfolio.</p>
               <button
                 onClick={() => setIsOpen(false)}
                 className="text-gray-300 hover:text-gray-100 text-xl"
@@ -203,7 +194,7 @@ export default function Chatbot() {
             </div>
 
             {/* Input */}
-            <div className="p-4 border-t border-gray-700 bg-gray-900 flex gap-2">
+            <div className="sticky bottom-0 p-4 border-t border-gray-700 bg-gray-900 flex gap-2">
               <input
                 type="text"
                 value={input}
@@ -221,8 +212,7 @@ export default function Chatbot() {
                 {isLoading ? '...' : 'Send'}
               </button>
             </div>
-        </animated.div>
-      )}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- refactor Chatbot component to remove react-spring
- use Tailwind transitions for sliding effect and background gradients
- add floating logo button and sticky input field

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react-markdown')*

------
https://chatgpt.com/codex/tasks/task_e_687049d731a08321b0394c98670523ef