### PR TITLE
Enhance portfolio with animated hero

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Hero from './pages/Hero';
 import { About } from './pages/About';
 import { Projects } from './pages/Projects';
 import { Contact } from './pages/Contact';
@@ -46,6 +47,7 @@ export default function App() {
           </svg>
         </div>
         <div className="absolute top-[25%] left-[60%] w-96 h-96 bg-gradient-to-br from-blue-500 via-purple-500 to-pink-500 rounded-full blur-3xl opacity-10 animate-pulse -z-10" />
+        <Hero />
         <About />
         <Projects />
         <Contact />

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { useSpring, animated } from '@react-spring/web';
+
+const skills = ['Python', 'SQL', 'ML', 'R', 'Power BI', 'NLP', 'Forecasting'];
+
+export const Hero = () => {
+  const [index, setIndex] = useState(0);
+  const animation = useSpring({
+    key: index,
+    from: { opacity: 0, transform: 'translateY(12px)' },
+    to: { opacity: 1, transform: 'translateY(0px)' },
+    config: { mass: 1, tension: 170, friction: 26 },
+  });
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      setIndex((i) => (i + 1) % skills.length);
+    }, 2000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <section className="relative flex flex-col items-center justify-center text-center py-32 sm:py-40">
+      <div className="absolute inset-0 -z-10 opacity-20 pointer-events-none">
+        <svg viewBox="0 0 500 100" className="w-full h-full" preserveAspectRatio="none">
+          <polyline
+            points="0,80 50,60 100,65 150,40 200,50 250,30 300,40 350,20 400,30 450,10 500,20"
+            fill="none"
+            stroke="url(#grad)"
+            strokeWidth="3"
+          >
+            <animate attributeName="stroke-dashoffset" from="100" to="0" dur="3s" repeatCount="indefinite" />
+          </polyline>
+          <defs>
+            <linearGradient id="grad" x1="0" y1="0" x2="100%" y2="0">
+              <stop offset="0%" stopColor="#818cf8" />
+              <stop offset="100%" stopColor="#ec4899" />
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+      <h1 className="text-5xl sm:text-7xl font-extrabold mb-4 bg-gradient-to-r from-indigo-400 via-purple-500 to-pink-500 bg-clip-text text-transparent animate-gradient-x [background-size:200%_200%] [animation-duration:6s]">
+        Ayush Patel
+      </h1>
+      <p className="text-lg text-zinc-300 max-w-xl">
+        Data scientist turning complex data into clear insight.
+      </p>
+      <div className="mt-6 text-2xl font-mono text-blue-300 h-8">
+        <animated.span style={animation}>{skills[index]}</animated.span>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;


### PR DESCRIPTION
## Summary
- introduce new `Hero` section with rotating skills and animated chart background
- integrate `Hero` at the top of the application

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6874568418188321bf2fb546a65662d0