### PR TITLE
feat: add sticky navbar with active section highlighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { About } from './pages/About';
 import { Projects } from './pages/Projects';
 import { Contact } from './pages/Contact';
 import Chatbot from './components/Chatbot';
+import NavBar from './components/NavBar';
 
 interface AnimatedCounterProps {
   to: number;
@@ -57,6 +58,7 @@ export default function App() {
   }, []);
   return (
     <div className="font-sans text-white min-h-screen bg-[radial-gradient(1200px_600px_at_70%_0%,rgba(110,168,255,0.10),transparent_60%),linear-gradient(to_bottom,#0a0f1c,#1a2238)]">
+      <NavBar />
       <main className="relative max-w-6xl mx-auto px-6 py-6 space-y-16 glass rounded-3xl soft-shadow border overflow-hidden transition-shadow hover:shadow-[0_0_30px_rgba(110,168,255,0.25)]">
         <div className="absolute inset-0 -z-10 opacity-5 pointer-events-none">
           <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const sections = ['about', 'projects', 'contact'];
+
+export default function NavBar() {
+  const [active, setActive] = useState('');
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.6 }
+    );
+
+    sections.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  const linkClass = (id: string) =>
+    `transition-colors hover:text-[var(--blue)] ${active === id ? 'text-[var(--blue)]' : ''}`;
+
+  return (
+    <nav className="sticky top-0 z-50 backdrop-blur bg-black/30">
+      <ul className="flex justify-center gap-8 py-4">
+        {sections.map((id) => (
+          <li key={id}>
+            <a href={`#${id}`} className={linkClass(id)}>
+              {id.charAt(0).toUpperCase() + id.slice(1)}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+html {
+  scroll-behavior: smooth;
+}


### PR DESCRIPTION
## Summary
- add sticky, semi-transparent navbar with smooth scrolling links
- highlight active section via IntersectionObserver
- enable global smooth scrolling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acf7b014cc83218212a59993a1cc5f